### PR TITLE
Add Linux arm64 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: arm64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Found your project on the Android Weekly newsletter but couldn't test because of the architecture.

So here is a PR that would fix it for me. Thanks!

Add the ubuntu latest arm variant (according to this https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job)

ps.: I would appreciate a release after this is approved :smile_cat: 
